### PR TITLE
Remove ngx-uid and its usages because it is not needed. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ npm install --save @rosen-group/ngx-onboarding
 
 - [angular-material](https://www.npmjs.com/package/angular-material)
 - [@angular/cdk](https://www.npmjs.com/package/@angular/cdk)
-- [ngx-uid](https://www.npmjs.com/package/ngx-uid)
 
 For detailed information how to use Angular material please have a look at the [Angular material getting started page](https://material.angular.io/guide/getting-started) and follow the installations instructions.
 
@@ -67,8 +66,7 @@ Add the OnboardingModule, the OnboardingService and it's dependencies to your mo
         MatIconModule,
         MatButtonModule,
         OnboardingModule
-    ],
-    providers: [OnboardingService],
+    ]
 ```
 
 Add some styles, e.g. to your app.component.css ()

--- a/package-lock.json
+++ b/package-lock.json
@@ -6905,11 +6905,6 @@
         }
       }
     },
-    "ngx-uid": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ngx-uid/-/ngx-uid-1.1.1.tgz",
-      "integrity": "sha512-T41/+7XjVr5yw7/749RsC+jZBjqjpziOWF1gUlpiraQaxXLN7c6OH/M3sXNgTZIFYo/ywd4taE9IAcwYnSR4Bw=="
-    },
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
         "@angular/router": "^6.1.0",
         "classlist.js": "^1.1.20150312",
         "core-js": "^2.5.4",
-        "ngx-uid": "^1.1.1",
         "reflect-metadata": "^0.1.12",
         "rxjs": "^6.0.0",
         "web-animations-js": "^2.3.1",

--- a/projects/ngx-onboarding/package.json
+++ b/projects/ngx-onboarding/package.json
@@ -22,7 +22,6 @@
         "@angular/http": "^6.1.0",
         "@angular/material": "^6.4.6",
         "lodash": "^4.17.11",
-        "ngx-uid": "^1.1.1",
         "rxjs": "^6.0.0",
         "zone.js": "~0.8.26"
     },

--- a/projects/ngx-onboarding/src/lib/onboarding.module.ts
+++ b/projects/ngx-onboarding/src/lib/onboarding.module.ts
@@ -15,7 +15,6 @@ import {
     TranslatorBaseService,
     WindowRef
 } from './services';
-import { NgxUidModule } from 'ngx-uid';
 import { PrimitiveTranslatePipe } from './pipes';
 
 /**
@@ -29,8 +28,7 @@ import { PrimitiveTranslatePipe } from './pipes';
         MatBadgeModule,
         MatIconModule,
         MatMenuModule,
-        HttpClientModule,
-        NgxUidModule.forRoot()
+        HttpClientModule
     ],
     declarations: [
         OnboardingComponent,

--- a/projects/ngx-onboarding/src/lib/services/onboarding.service.mock.ts
+++ b/projects/ngx-onboarding/src/lib/services/onboarding.service.mock.ts
@@ -1,5 +1,5 @@
-import { OnboardingConfiguration, OnboardingItem, OnboardingItemContainer } from '../models';
-import { EventEmitter } from '@angular/core';
+import {OnboardingConfiguration, OnboardingItem, OnboardingItemContainer} from '../models';
+import {EventEmitter} from '@angular/core';
 
 /**
  * Mock implementation for OnboardingService
@@ -10,7 +10,6 @@ export class OnboardingServiceMock {
 
     public readonly visibleItems = new OnboardingItemContainer();
     public visibleItemsChanged = new EventEmitter();
-    public readonly instanceId: string;
 
     public get registeredItemsCount(): number {
         return 1;

--- a/projects/ngx-onboarding/src/lib/services/onboarding.service.mock.ts
+++ b/projects/ngx-onboarding/src/lib/services/onboarding.service.mock.ts
@@ -1,5 +1,5 @@
-import {OnboardingConfiguration, OnboardingItem, OnboardingItemContainer} from '../models';
-import {EventEmitter} from '@angular/core';
+import { OnboardingConfiguration, OnboardingItem, OnboardingItemContainer } from '../models';
+import { EventEmitter } from '@angular/core';
 
 /**
  * Mock implementation for OnboardingService

--- a/projects/ngx-onboarding/src/lib/services/onboarding.service.spec.ts
+++ b/projects/ngx-onboarding/src/lib/services/onboarding.service.spec.ts
@@ -5,7 +5,6 @@ import { OnboardingItem } from '../models';
 import { SeenSelectorsBaseService } from './seen-selectors-base.service';
 import { MockLocalStorageSeenSelectorsService } from './local-storage-seen-selectors.service.mock';
 import { MockLocalStorageEnabledStatusService } from './local-storage-enabled-status.service.mock';
-import { NgxUidService } from 'ngx-uid';
 import { EnabledStatusBaseService } from './enabled-status-base.service';
 
 describe('OnboardingService', () => {
@@ -14,7 +13,6 @@ describe('OnboardingService', () => {
             providers: [
                 BrowserDOMSelectorService,
                 OnboardingService,
-                NgxUidService,
                 {provide: SeenSelectorsBaseService, useClass: MockLocalStorageSeenSelectorsService},
                 {provide: EnabledStatusBaseService, useClass: MockLocalStorageEnabledStatusService}
             ],

--- a/projects/ngx-onboarding/src/lib/services/onboarding.service.ts
+++ b/projects/ngx-onboarding/src/lib/services/onboarding.service.ts
@@ -11,7 +11,6 @@ import {
 } from '../models';
 import { SeenSelectorsBaseService } from './seen-selectors-base.service';
 import { EnabledStatusBaseService } from './enabled-status-base.service';
-import { NgxUidService } from 'ngx-uid';
 
 const addSeenSelectorDebounceTime = 1000;
 const enabledChangedDebounceTime = 1000;
@@ -39,7 +38,6 @@ export class OnboardingService {
      * called by OnboardingComponent
      */
     public visibleItemsChanged = new EventEmitter();
-    public readonly instanceId: string;
     private addSeenSelectorDebounceSubscription: Subscription;
     private enabledChangedDebounceSubscription: Subscription;
     private refreshSubscription: Subscription;
@@ -65,9 +63,7 @@ export class OnboardingService {
                 private loadAndSaveSeenSelectorsService: SeenSelectorsBaseService,
                 private loadAndSaveEnabledStatusService: EnabledStatusBaseService,
                 private errorHandler: ErrorHandler,
-                private zone: NgZone,
-                uidService: NgxUidService) {
-        this.instanceId = uidService.next();
+                private zone: NgZone) {
         this.configuration = this.defaultConfiguration;
         /* this is the default setting. can be changed by configure()*/
         this.init();

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
-import { OnboardingModule, OnboardingService } from '../../projects/ngx-onboarding/src';
+import { OnboardingModule } from '../../projects/ngx-onboarding/src';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatButtonModule, MatIconModule } from '@angular/material';
 import { HttpClientModule } from '@angular/common/http';
@@ -22,7 +22,7 @@ import { HttpClientModule } from '@angular/common/http';
         MatButtonModule,
         HttpClientModule
     ],
-    providers: [OnboardingService],
+    providers: [],
     bootstrap: [AppComponent]
 })
 export class AppModule {


### PR DESCRIPTION
Remove ngx-uid and its usages because it is not needed. The instanceid generated with it is never used anywhere.

This time i removed it also from the application

Also removed a superflus import of the onboarding service