### PR TITLE
provide all services as "singleton"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ testem.log
 Thumbs.db
 
 .npmrc
+reports

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "ng serve",
     "build": "ng build",
     "test": "ng test ngx-onboarding",
+      "test-coverage-report": "ng test ngx-onboarding --code-coverage --watch=false",
     "test-app": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "start": "ng serve",
     "build": "ng build",
     "test": "ng test ngx-onboarding",
-      "test-coverage-report": "ng test ngx-onboarding --code-coverage --watch=false",
     "test-app": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",

--- a/projects/ngx-onboarding/src/lib/services/build-in-translator.service.ts
+++ b/projects/ngx-onboarding/src/lib/services/build-in-translator.service.ts
@@ -5,7 +5,9 @@ import { TranslatorBaseService } from './translator-base.service';
 /**
  * Service for the translations of internal text
  */
-@Injectable()
+@Injectable(
+    {providedIn: 'root' /* makes sure that service stays a single instance among seperate modules */}
+)
 export class BuildInTranslatorService extends TranslatorBaseService {
 
     /**

--- a/projects/ngx-onboarding/src/lib/services/enabled-status-base.service.ts
+++ b/projects/ngx-onboarding/src/lib/services/enabled-status-base.service.ts
@@ -5,7 +5,16 @@ import { Observable } from 'rxjs';
  * if you don't want to store the settings in the local storage
  */
 export abstract class EnabledStatusBaseService {
-    abstract save(enabled: boolean): Observable<never>;
 
+    /**
+     * saves the status to a persistent storage
+     * @returns success of the operation (true = good, false = failed)
+     */
+    abstract save(enabled: boolean): Observable<boolean>;
+
+    /**
+     * loads the status from the persistent storage
+     * @returns status (true = enabled, false = disabled)
+     */
     abstract load(): Observable<boolean>;
 }

--- a/projects/ngx-onboarding/src/lib/services/local-storage-enabled-status.service.mock.ts
+++ b/projects/ngx-onboarding/src/lib/services/local-storage-enabled-status.service.mock.ts
@@ -1,4 +1,4 @@
-import { EMPTY, Observable, of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { EnabledStatusBaseService } from './enabled-status-base.service';
 
 /**
@@ -10,7 +10,7 @@ export class MockLocalStorageEnabledStatusService extends EnabledStatusBaseServi
         return of(true);
     }
 
-    public save(enabled: boolean): Observable<never> {
-        return EMPTY;
+    public save(enabled: boolean): Observable<boolean> {
+        return of(true);
     }
 }

--- a/projects/ngx-onboarding/src/lib/services/local-storage-enabled-status.service.spec.ts
+++ b/projects/ngx-onboarding/src/lib/services/local-storage-enabled-status.service.spec.ts
@@ -1,74 +1,77 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { async, TestBed } from '@angular/core/testing';
 import { LocalStorageEnabledStatusService } from './local-storage-enabled-status.service';
 import { ErrorHandler } from '@angular/core';
 
 describe('LocalStorageEnabledStatusService', () => {
+    let errorHandler: ErrorHandler;
+    let service: LocalStorageEnabledStatusService;
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             providers: [
                 LocalStorageEnabledStatusService,
             ],
         });
+        errorHandler = TestBed.get(ErrorHandler);
+        service = TestBed.get(LocalStorageEnabledStatusService);
     }));
 
-    it('should be created', inject([LocalStorageEnabledStatusService], (service: LocalStorageEnabledStatusService) => {
+    it('should be created', () => {
         expect(service).toBeTruthy();
-    }));
+    });
 
-    it('load with true expect enabled to be true',
-        inject([LocalStorageEnabledStatusService], (service: LocalStorageEnabledStatusService) => {
+    it('load with true expect enabled to be true', done => {
             spyOn(localStorage, 'getItem').and.returnValue('true');
-
-            service.load().subscribe(enabled => {
-                expect(enabled).toBe(true);
+            service.load().subscribe((enabled: boolean) => {
+                expect(enabled).toEqual(true);
+                done();
             });
-        })
+        }
     );
 
-    it('load with getItem throws an error expect enabled to be true',
-        inject([LocalStorageEnabledStatusService, ErrorHandler],
-            (service: LocalStorageEnabledStatusService, errorHandler: ErrorHandler) => {
+    it('load with getItem throws an error expect enabled to be true', done => {
 
-                spyOn(localStorage, 'getItem').and.throwError('getItem failed');
-                const errorSpy = spyOn(errorHandler, 'handleError').and.stub();
-                service.load().subscribe(enabled => {
-                    expect(enabled).toBe(true);
-                    expect(errorSpy).toHaveBeenCalled();
-                });
-            })
-    );
-
-    it('save expect setItem to have been called with true',
-        inject([LocalStorageEnabledStatusService], (service: LocalStorageEnabledStatusService) => {
-            const spy = spyOn(localStorage, 'setItem').and.stub();
-
-            service.save(true);
-
-            expect(spy).toHaveBeenCalledWith('42cfe10a-c2d3-42ba-9c55-6198545a0c49', 'true');
-        })
-    );
-
-    it('save expect setItem to have been called with false',
-        inject([LocalStorageEnabledStatusService], (service: LocalStorageEnabledStatusService) => {
-            const spy = spyOn(localStorage, 'setItem').and.stub();
-
-            service.save(false);
-
-            expect(spy).toHaveBeenCalledWith('42cfe10a-c2d3-42ba-9c55-6198545a0c49', 'false');
-        })
-    );
-
-    it('save expect setItem to have been called with false',
-        inject([LocalStorageEnabledStatusService, ErrorHandler],
-            (service: LocalStorageEnabledStatusService, errorHandler: ErrorHandler) => {
-
-                spyOn(localStorage, 'setItem').and.throwError('setItem failed');
-                const errorSpy = spyOn(errorHandler, 'handleError').and.stub();
-
-                service.save(false);
-
+            spyOn(localStorage, 'getItem').and.throwError('getItem failed');
+            const errorSpy = spyOn(errorHandler, 'handleError').and.stub();
+            service.load().subscribe((enabled: boolean) => {
+                expect(enabled).toBe(true);
                 expect(errorSpy).toHaveBeenCalled();
-            })
+                done();
+            });
+        }
+    );
+
+    it('save expect setItem to have been called with true', done => {
+            const errorSpy = spyOn(errorHandler, 'handleError').and.stub();
+            const storageSpy = spyOn(localStorage, 'setItem').and.stub();
+            service.save(true).subscribe(() => {
+                expect(storageSpy).toHaveBeenCalledWith('42cfe10a-c2d3-42ba-9c55-6198545a0c49', 'true');
+                expect(errorSpy).not.toHaveBeenCalled();
+                done();
+            });
+        }
+    );
+
+    it('save expect setItem to have been called with false', done => {
+            const errorSpy = spyOn(errorHandler, 'handleError').and.stub();
+            const storageSpy = spyOn(localStorage, 'setItem').and.stub();
+            service.save(false).subscribe((success: boolean) => {
+                expect(storageSpy).toHaveBeenCalledWith('42cfe10a-c2d3-42ba-9c55-6198545a0c49', 'false');
+                expect(errorSpy).not.toHaveBeenCalled();
+                expect(success).toEqual(true);
+                done();
+            });
+        }
+    );
+
+    it('save expect setItem to call errorhandler if exception occurs', done => {
+            spyOn(localStorage, 'setItem').and.throwError('setItem failed');
+            const errorSpy = spyOn(errorHandler, 'handleError').and.stub();
+            service.save(false).subscribe((success: boolean) => {
+                expect(errorSpy).toHaveBeenCalled();
+                expect(success).toEqual(false);
+                done();
+            });
+        }
     );
 
 });

--- a/projects/ngx-onboarding/src/lib/services/local-storage-enabled-status.service.ts
+++ b/projects/ngx-onboarding/src/lib/services/local-storage-enabled-status.service.ts
@@ -1,4 +1,4 @@
-import { EMPTY, Observable, of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { ErrorHandler, Injectable } from '@angular/core';
 import { EnabledStatusBaseService } from './enabled-status-base.service';
 
@@ -14,13 +14,19 @@ const enabledLocalStorageKey = '42cfe10a-c2d3-42ba-9c55-6198545a0c49';
  * from the EnabledStatusBaseService and use the provide feature in your app.module with
  * {provide: EnabledStatusBaseService, useClass: YourOwnEnabledStatusService}
  */
-@Injectable()
+@Injectable(
+    {providedIn: 'root' /* makes sure that service stays a single instance among seperate modules */}
+)
 export class LocalStorageEnabledStatusService extends EnabledStatusBaseService {
 
     constructor(private errorHandler: ErrorHandler) {
         super();
     }
 
+    /**
+     * loads the status from the persistent storage
+     * @returns status (true = enabled, false = disabled)
+     */
     public load(): Observable<boolean> {
         try {
             return of('true' === localStorage.getItem(enabledLocalStorageKey));
@@ -30,12 +36,17 @@ export class LocalStorageEnabledStatusService extends EnabledStatusBaseService {
         return of(true);
     }
 
-    public save(enabled: boolean): Observable<never> {
+    /**
+     * saves the status to localStorage
+     * @returns success of the operation (true = good, false = failed)
+     */
+    public save(enabled: boolean): Observable<boolean> {
         try {
             localStorage.setItem(enabledLocalStorageKey, enabled ? 'true' : 'false');
+            return of(true);
         } catch (error) {
             this.errorHandler.handleError(error);
         }
-        return EMPTY;
+        return of(false);
     }
 }

--- a/projects/ngx-onboarding/src/lib/services/local-storage-seen-selectors.service.spec.ts
+++ b/projects/ngx-onboarding/src/lib/services/local-storage-seen-selectors.service.spec.ts
@@ -1,70 +1,70 @@
-import { async, inject, TestBed } from '@angular/core/testing';
+import { async, TestBed } from '@angular/core/testing';
 import { LocalStorageSeenSelectorsService } from './local-storage-seen-selectors.service';
 import { ErrorHandler } from '@angular/core';
 
 describe('LocalStorageSeenSelectorsService', () => {
+    let errorHandler: ErrorHandler;
+    let service: LocalStorageSeenSelectorsService;
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             providers: [
                 LocalStorageSeenSelectorsService,
             ],
         });
+        errorHandler = TestBed.get(ErrorHandler);
+        service = TestBed.get(LocalStorageSeenSelectorsService);
     }));
 
-    it('should be created',
-        inject([LocalStorageSeenSelectorsService], (service: LocalStorageSeenSelectorsService) => {
-            expect(service).toBeTruthy();
-        })
-    );
+    it('should be created', () => {
+        expect(service).toBeDefined();
+    });
 
-    it('load expect seenSelectors.length to be 3',
-        inject([LocalStorageSeenSelectorsService], (service: LocalStorageSeenSelectorsService) => {
+    it('load expect seenSelectors.length to be 3', done => {
             spyOn(localStorage, 'getItem').and.returnValue('["a","b","c"]');
 
-            service.load().subscribe(seenSelectors => {
-                expect(seenSelectors.length).toBe(3);
-                expect(seenSelectors[1]).toBe('b');
+            service.load().subscribe((seenSelectors: Array<string>) => {
+                expect(seenSelectors.length).toEqual(3);
+                expect(seenSelectors[1]).toEqual('b');
+                done();
             });
-        })
+        }
     );
 
     it('load with localStorage.getItem returns invalid json string expect seenSelectors.length to be 0 ',
-        inject([LocalStorageSeenSelectorsService, ErrorHandler],
-            (service: LocalStorageSeenSelectorsService, errorHandler: ErrorHandler) => {
+        done => {
 
-                spyOn(localStorage, 'getItem').and.returnValue('invalid json string');
-                const spy = spyOn(errorHandler, 'handleError').and.stub();
+            spyOn(localStorage, 'getItem').and.returnValue('invalid json string');
+            const spy = spyOn(errorHandler, 'handleError').and.stub();
 
-                service.load().subscribe(seenSelectors => {
-                    expect(seenSelectors.length).toBe(0);
-                    expect(spy).toHaveBeenCalled();
-                });
-            })
+            service.load().subscribe(seenSelectors => {
+                expect(seenSelectors.length).toBe(0);
+                expect(spy).toHaveBeenCalled();
+                done();
+            });
+        }
     );
 
     it('save expect localStorage.setItem to have been called',
-        inject([LocalStorageSeenSelectorsService], (service: LocalStorageSeenSelectorsService) => {
+        done => {
             const spy = spyOn(localStorage, 'setItem').and.stub();
-
-            service.save(['A', 'B', 'C']).subscribe(result => {
+            service.save(['A', 'B', 'C']).subscribe((result: boolean) => {
                 expect(result).toBe(true);
                 expect(spy).toHaveBeenCalledWith('894ae732-b4bd-45c9-b543-6f9c5c5a86b6', '["A","B","C"]');
+                done();
             });
-        })
+        }
     );
 
     it('save with localStorage.getItem throws error expect errorHandler to have been called',
-        inject([LocalStorageSeenSelectorsService, ErrorHandler],
-            (service: LocalStorageSeenSelectorsService, errorHandler: ErrorHandler) => {
-
-                spyOn(localStorage, 'setItem').and.throwError('setItem failed');
-                const spy = spyOn(errorHandler, 'handleError').and.stub();
-
-                service.save(['A', 'B', 'C']).subscribe(result => {
-                    expect(result).toBe(false);
-                    expect(spy).toHaveBeenCalled();
-                });
-            })
+        done => {
+            spyOn(localStorage, 'setItem').and.throwError('setItem failed');
+            const spy = spyOn(errorHandler, 'handleError').and.stub();
+            service.save(['A', 'B', 'C']).subscribe((result: boolean) => {
+                expect(result).toBe(false);
+                expect(spy).toHaveBeenCalled();
+                done();
+            });
+        }
     );
-
 });
+

--- a/projects/ngx-onboarding/src/lib/services/local-storage-seen-selectors.service.ts
+++ b/projects/ngx-onboarding/src/lib/services/local-storage-seen-selectors.service.ts
@@ -22,6 +22,10 @@ export class LocalStorageSeenSelectorsService extends SeenSelectorsBaseService {
         super();
     }
 
+    /**
+     * loads seen items from localStorage
+     * @returns string array of all seen selectors
+     */
     public load(): Observable<Array<string>> {
         const seenSelectorsString = localStorage.getItem(seenSelectorsLocalStorageKey);
         if (!_.isEmpty(seenSelectorsString)) {
@@ -34,6 +38,10 @@ export class LocalStorageSeenSelectorsService extends SeenSelectorsBaseService {
         return of([]);
     }
 
+    /**
+     * save items to localStorage
+     * @returns success of the operation (true = good, false = failed)
+     */
     public save(seenSelectors: Array<string>): Observable<boolean> {
         try {
             localStorage.setItem(seenSelectorsLocalStorageKey, JSON.stringify(seenSelectors));

--- a/projects/ngx-onboarding/src/lib/services/onboarding.service.ts
+++ b/projects/ngx-onboarding/src/lib/services/onboarding.service.ts
@@ -23,7 +23,7 @@ const refreshTime = 2000;
  * The OnboardingComponent listens to the visibleItemsChanged event and retrieves new onboarding items from the visibleItems object.
  */
 @Injectable({
-    providedIn: 'root'
+    providedIn: 'root' /* makes sure that service stays a single instance among seperate modules */
 })
 export class OnboardingService {
 

--- a/projects/ngx-onboarding/src/lib/services/seen-selectors-base.service.ts
+++ b/projects/ngx-onboarding/src/lib/services/seen-selectors-base.service.ts
@@ -6,8 +6,16 @@ import { Observable } from 'rxjs';
  */
 export abstract class SeenSelectorsBaseService {
 
+    /**
+     * loads seen items from a persistent storage
+     * @returns string array of all seen selectors
+     */
     abstract load(): Observable<Array<string>>;
 
+    /**
+     * save items to a persistent storage
+     * @returns success of the operation (true = good, false = failed)
+     */
     abstract save(seenSelectors: Array<string>): Observable<boolean>;
 
 }

--- a/projects/ngx-onboarding/src/lib/services/window-ref.service.ts
+++ b/projects/ngx-onboarding/src/lib/services/window-ref.service.ts
@@ -10,7 +10,9 @@ function _window(): any {
 /**
  * Abstraction of the window reference
  */
-@Injectable()
+@Injectable(
+    {providedIn: 'root' /* makes sure that service stays a single instance among seperate modules */}
+)
 export class WindowRef {
 
     public get nativeWindow(): any {

--- a/projects/ngx-onboarding/tsconfig.lib.json
+++ b/projects/ngx-onboarding/tsconfig.lib.json
@@ -28,6 +28,7 @@
     },
     "exclude": [
         "src/test.ts",
+        "**/*.mock.ts",
         "**/*.spec.ts"
     ]
 }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,24 +1,53 @@
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
-import { OnboardingModule, OnboardingService } from '../../projects/ngx-onboarding/src';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { OnboardingServiceMock } from '../../projects/ngx-onboarding/src/lib/services/onboarding.service.mock';
+import { OnboardingModule } from '../../projects/ngx-onboarding/src';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpClient } from '@angular/common/http';
+import { ErrorHandler } from '@angular/core';
+
 
 describe('AppComponent', () => {
-    beforeEach(async(() => {
+    let httpClient: HttpClient;
+    let httpTestingController: HttpTestingController;
+    let errorHandler: ErrorHandler;
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [OnboardingModule, HttpClientTestingModule],
             declarations: [
                 AppComponent
-            ],
-            providers: [
-                {provide: OnboardingService, useClass: OnboardingServiceMock}
             ]
-        }).compileComponents();
-    }));
-    it('should create the app', async(() => {
+        });
+        httpClient = TestBed.get(HttpClient);
+        httpTestingController = TestBed.get(HttpTestingController);
+        errorHandler = TestBed.get(ErrorHandler);
+    });
+    afterEach(() => {
+        httpTestingController.verify();
+    });
+    it('should create the app and load onboarding data', () => {
+        const errSpy = spyOn(errorHandler, 'handleError');
         const fixture = TestBed.createComponent(AppComponent);
         const app = fixture.debugElement.componentInstance;
-        expect(app).toBeTruthy();
-    }));
+        expect(app).toBeDefined();
+        fixture.detectChanges();
+        const req = httpTestingController.expectOne('assets/onboarding/example.json');
+        req.flush(
+            {
+                'selector': '.css-class-1',
+                'group': 'group 1',
+                'position': 'top',
+                'headline': 'headline 1',
+                'details': 'details 1',
+                'descriptions': [
+                    {
+                        'language': 'de',
+                        'headline': 'headline 1 de',
+                        'details': 'details 1 de'
+                    }
+                ]
+            }
+        );
+        expect(errSpy).not.toHaveBeenCalled();
+
+    });
 });


### PR DESCRIPTION
use "real" async observable everywhere (in tests and services)
exclude mocks from lib compilation
add code coverage report to package.json (else only junit.xml is generated)